### PR TITLE
Fix display of graph with many plots

### DIFF
--- a/hdr_plot/hdr_plot.py
+++ b/hdr_plot/hdr_plot.py
@@ -154,7 +154,7 @@ def plot_percentiles(percentiles, labels, units, percentiles_range_max):
     majors = all_percentile_labels[0:percentiles_max_index + 1]
     ax.xaxis.set_major_formatter(ticker.FixedFormatter(majors))
     ax.xaxis.set_minor_formatter(ticker.NullFormatter())
-    plt.legend(bbox_to_anchor=(0.125, 0.01, 1, 0.102), bbox_transform=fig.transFigure, loc=3, ncol=2,
+    plt.legend(bbox_to_anchor=(0.125, 0.01, 1, 0.102), bbox_transform=fig.transFigure, loc=3, ncol=3,
                borderaxespad=0, labels=labels)
     # make room for the legend
     plt.subplots_adjust(bottom=0.11)

--- a/hdr_plot/hdr_plot.py
+++ b/hdr_plot/hdr_plot.py
@@ -124,7 +124,7 @@ def plot_summarybox(fig, ax, percentiles, metadata, labels, units, summary_field
             if previous_box is None:
                 previous_box = info_box(ax, textstr, 0.01)
             else:
-                # align the second box next to the first one by retrieving its width
+                # align the box next to the previous one
                 previous_box_dimensions = previous_box.get_window_extent(renderer=fig.canvas.get_renderer())
                 previous_box_edge = previous_box_dimensions.x1, 0
                 current_box_edge_axes_coords = ax.transAxes.inverted().transform(previous_box_edge)
@@ -160,7 +160,7 @@ def plot_percentiles(percentiles, labels, units, percentiles_range_max):
     majors = all_percentile_labels[0:percentiles_max_index + 1]
     ax.xaxis.set_major_formatter(ticker.FixedFormatter(majors))
     ax.xaxis.set_minor_formatter(ticker.NullFormatter())
-    # we would like the labels not to be higher than 3
+    # we would like the labels box to have at most 3 lines
     n_col = math.ceil(len(labels) / 3)
     plt.legend(bbox_to_anchor=(0.125, 0.01, 1, 0.102), bbox_transform=fig.transFigure, loc=3, ncol=n_col,
                borderaxespad=0, labels=labels)

--- a/hdr_plot/hdr_plot.py
+++ b/hdr_plot/hdr_plot.py
@@ -109,20 +109,25 @@ def info_box(ax, text, x):
 
 def plot_summarybox(fig, ax, percentiles, metadata, labels, units, summary_fields):
     # add info box to the side
-    if len(labels) < 5:
+    box_length = 5
+    if len(labels) <= box_length:
         textstr = '\n'.join([info_text(labels[i], percentiles[i], metadata[i], units, summary_fields) for i in range(len(labels))])
         info_box(ax, textstr, 0.02)
     else:
-        textstr1 = '\n'.join([info_text(labels[i], percentiles[i], metadata[i], units, summary_fields) for i in range(4)])
-        textstr2 = '\n'.join([info_text(labels[i], percentiles[i], metadata[i], units, summary_fields) for i in range(4, len(labels))])
+        previous_box = None
+        for n in range(0, len(labels), box_length):
+            start = n
+            end = min(n + box_length, len(labels))
+            textstr = '\n'.join([info_text(labels[i], percentiles[i], metadata[i], units, summary_fields) for i in range(start, end)])
 
-        box1 = info_box(ax, textstr1, 0.01)
-
-        # align the second box next to the first one by retrieving its width
-        box1_dimensions = box1.get_window_extent(renderer=fig.canvas.get_renderer())
-        box1_edge = box1_dimensions.x1, 0
-        box2_edge_axes_coords = ax.transAxes.inverted().transform(box1_edge)
-        info_box(ax, textstr2, box2_edge_axes_coords[0] + 0.01)
+            if previous_box is None:
+                previous_box = info_box(ax, textstr, 0.01)
+            else:
+                # align the second box next to the first one by retrieving its width
+                previous_box_dimensions = previous_box.get_window_extent(renderer=fig.canvas.get_renderer())
+                previous_box_edge = previous_box_dimensions.x1, 0
+                current_box_edge_axes_coords = ax.transAxes.inverted().transform(previous_box_edge)
+                previous_box = info_box(ax, textstr, current_box_edge_axes_coords[0] + 0.01)
 
 
 def plot_percentiles(percentiles, labels, units, percentiles_range_max):

--- a/hdr_plot/hdr_plot.py
+++ b/hdr_plot/hdr_plot.py
@@ -14,6 +14,7 @@
 import argparse
 import re
 import sys
+import math
 import pandas as pd
 import matplotlib.pyplot as plt
 import matplotlib.ticker as ticker
@@ -159,7 +160,9 @@ def plot_percentiles(percentiles, labels, units, percentiles_range_max):
     majors = all_percentile_labels[0:percentiles_max_index + 1]
     ax.xaxis.set_major_formatter(ticker.FixedFormatter(majors))
     ax.xaxis.set_minor_formatter(ticker.NullFormatter())
-    plt.legend(bbox_to_anchor=(0.125, 0.01, 1, 0.102), bbox_transform=fig.transFigure, loc=3, ncol=3,
+    # we would like the labels not to be higher than 3
+    n_col = math.ceil(len(labels) / 3)
+    plt.legend(bbox_to_anchor=(0.125, 0.01, 1, 0.102), bbox_transform=fig.transFigure, loc=3, ncol=n_col,
                borderaxespad=0, labels=labels)
     # make room for the legend
     plt.subplots_adjust(bottom=0.11)


### PR DESCRIPTION
Fox graphs that have many plots (10 or more), the current implementation isn't optimal:
- the first summary box is too small whereas the second one overflows
- the label legend box grows too big

This PR fixes these issues by:
- rendering more summary boxes when necessary
- dynamically adjusting the number of columns of the label legend box so that there are no more than 3 rows in each column