### PR TITLE
Display max instead of 0.0 when no data is available

### DIFF
--- a/hdr_plot/hdr_plot.py
+++ b/hdr_plot/hdr_plot.py
@@ -67,7 +67,7 @@ def info_text(name, data, metadata, units, summary_fields):
         if not df.empty:
             return df.iloc[0]
         else:
-            return 0.0
+            return max
 
     percentiles = {
         'p50': 0.50,


### PR DESCRIPTION
A small improvement: instead of showing `0.0` in the summary box when no data is available at a given percentile (e.g. p9999), this fix displays the next available value (i.e. `max`)